### PR TITLE
Add fontfaceobserver & sans-serif styles to prevent horrible FOUT

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -9,12 +9,26 @@ import { AsyncComponentProvider } from 'react-async-component'
 import { JobProvider } from 'react-jobs'
 import { Provider } from 'react-redux'
 import { ThemeProvider } from 'styled-components'
-import configureStore from '../shared/redux/configureStore'
+import FontFaceObserver from 'fontfaceobserver'
 
 import './polyfills'
 
+import configureStore from '../shared/redux/configureStore'
 import theme from '../shared/components/theme'
 import App from '../shared/components/App'
+
+// Observe loading of our custom font
+const latoObserver = new FontFaceObserver('Lato', {})
+
+// When our custom font has loaded, add a class to the body
+latoObserver.load().then(
+  () => {
+    document.body.classList.add('fontloaded')
+  },
+  () => {
+    document.body.classList.remove('fontloaded')
+  },
+)
 
 // Get the DOM Element that will host our React application.
 const container = document.querySelector('#app')

--- a/package-lock.json
+++ b/package-lock.json
@@ -5762,6 +5762,11 @@
         }
       }
     },
+    "fontfaceobserver": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.0.13.tgz",
+      "integrity": "sha1-R627NDJh7amMtE2yFSGW/xJNMiE="
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dotenv": "5.0.0",
     "express": "4.16.2",
     "final-form": "4.2.0",
+    "fontfaceobserver": "2.0.13",
     "helmet": "3.10.0",
     "hpp": "0.2.2",
     "isomorphic-fetch": "2.2.1",

--- a/shared/components/globalStyles.js
+++ b/shared/components/globalStyles.js
@@ -8,9 +8,28 @@ injectGlobal`
   }
 
   body {
-    font-family: 'Lato', sans-serif;
+    /*
+      https://meowni.ca/font-style-matcher/
+
+      Styles created using the above tool to try and ensure the FOUT
+      (flash of unstyled text) doesn't look drastically different. This
+      will try to ensure that when "Lato" is downloaded, it doesn't look
+      too different to "sans-serif" and, more importantly, doesn't affect
+      the layout of the page too much.
+    */
+    font-family: sans-serif;
     font-size: 1rem;
     line-height: 1.5rem;
+    letter-spacing: -0.1px;
+    word-spacing: -0.1px;
+
+    &.fontloaded {
+      font-family: 'Lato';
+      font-size: 1rem;
+      line-height: 1.5rem;
+      letter-spacing: 0px;
+      word-spacing: 0px;
+    }
   }
 
   *,


### PR DESCRIPTION
- Add fontfaceobserver to add a class to <body> when the custom font is downloaded
- Apply styles from [Font style matcher](https://meowni.ca/font-style-matcher/) to ensure the FOUT (Flash of Unstyled Text) doesn't look horrible. The goal is to make sans-serif look as similar to Lato as possible. This means when Lato is downloaded, the layout of the page should change as little as possible.